### PR TITLE
Update nugets name to contain .Studio2019 (required to identify the S…

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -110,3 +110,6 @@
 
 ### New in 1.9.0
 * Updated the LanguagePlatform Xliff converter to associate the target culture when reading target segments
+
+### New in 1.9.1
+* Update the Sdl.Community.Toolkit nugets names to contain .Studio2019 at the end of each package name

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -3,14 +3,14 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyProductAttribute("Sdl Studio Community Toolkit")]
-[assembly: AssemblyVersionAttribute("1.9.0")]
-[assembly: AssemblyFileVersionAttribute("1.9.0")]
+[assembly: AssemblyVersionAttribute("1.9.1")]
+[assembly: AssemblyFileVersionAttribute("1.9.1")]
 [assembly: ComVisibleAttribute(false)]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyProduct = "Sdl Studio Community Toolkit";
-        internal const System.String AssemblyVersion = "1.9.0";
-        internal const System.String AssemblyFileVersion = "1.9.0";
+        internal const System.String AssemblyVersion = "1.9.1";
+        internal const System.String AssemblyFileVersion = "1.9.1";
         internal const System.Boolean ComVisible = false;
     }
 }

--- a/build.fsx
+++ b/build.fsx
@@ -72,7 +72,7 @@ Target "CreateCorePackage" (fun _ ->
     NuGet (fun p -> 
         {p with
             Authors = authors
-            Project = "Sdl.Community.Toolkit.Core"
+            Project = "Sdl.Community.Toolkit.Core.Studio2019"
             Description = projectDescription
             OutputPath = packagingRoot
             Summary = projectSummary
@@ -95,7 +95,7 @@ Target "CreateFileTypePackage" (fun _ ->
     NuGet (fun p -> 
         {p with
             Authors = authors
-            Project = "Sdl.Community.Toolkit.FileType"
+            Project = "Sdl.Community.Toolkit.FileType.Studio2019"
             Description = projectDescription
             OutputPath = packagingRoot
             Summary = projectSummary
@@ -118,7 +118,7 @@ Target "CreateProjectAutomationPackage" (fun _ ->
     NuGet (fun p -> 
         {p with
             Authors = authors
-            Project = "Sdl.Community.Toolkit.ProjectAutomation"
+            Project = "Sdl.Community.Toolkit.ProjectAutomation.Studio2019"
             Description = projectDescription
             OutputPath = packagingRoot
             Summary = projectSummary
@@ -141,7 +141,7 @@ Target "CreateLanguagePlatformPackage" (fun _ ->
     NuGet (fun p -> 
         {p with
             Authors = authors
-            Project = "Sdl.Community.Toolkit.LanguagePlatform"
+            Project = "Sdl.Community.Toolkit.LanguagePlatform.Studio2019"
             Description = projectDescription
             OutputPath = packagingRoot
             Summary = projectSummary
@@ -164,7 +164,7 @@ Target "CreateIntegrationPackage" (fun _ ->
     NuGet (fun p -> 
         {p with
             Authors = authors
-            Project = "Sdl.Community.Toolkit.Integration"
+            Project = "Sdl.Community.Toolkit.Integration.Studio2019"
             Description = projectDescription
             OutputPath = packagingRoot
             Summary = projectSummary


### PR DESCRIPTION
…tudio 2019 Toolkit packages from future nuget packages compatible with Studio 2021)